### PR TITLE
Fixed erroneous truncating of TXT records which contained semi-colons

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Changes in Parse::DNS::Zone
+0.52 (2015-11-27)
+=================
+* Fixed erroneous parsing of TXT records with semi-colon in
+  them.
 
 0.51 (2015-02-18)
 =================

--- a/lib/Parse/DNS/Zone.pm
+++ b/lib/Parse/DNS/Zone.pm
@@ -58,7 +58,7 @@ Parse::DNS::Zone does not support $GENERATE in this version.
 
 use 5.010;
 package Parse::DNS::Zone;
-our $VERSION = '0.51';
+our $VERSION = '0.52';
 use warnings;
 use strict;
 use File::Basename;
@@ -448,7 +448,7 @@ sub _parse_zone {
 
 	for (split /\n/, $zonestr) {
 		chomp;
-		s/;.*$//;
+		s/;[^"']*$//;
 		next if /^\s*$/;
 		s/\s+/ /g;
 


### PR DESCRIPTION
In the case of TXT records for domain-keys used to authenticate email marketing, there are times when a semi-colon might appear within the rdata.
