### PR TITLE
Fix and test parsing of domain key TXT records

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,8 @@ t/01-dist.t
 t/03-filehandling.t
 t/03-fqdnize.t
 t/03-parser.t
+t/04-domainkey.t
 t/data/db.include
 t/data/db.nottl
 t/data/db.simple
+t/data/db.domainkey

--- a/lib/Parse/DNS/Zone.pm
+++ b/lib/Parse/DNS/Zone.pm
@@ -448,7 +448,7 @@ sub _parse_zone {
 
 	for (split /\n/, $zonestr) {
 		chomp;
-		s/;.*$//;
+		s/(?<!\\);.*$//;
 		next if /^\s*$/;
 		s/\s+/ /g;
 
@@ -505,6 +505,8 @@ sub _parse_zone {
 		}
 
 		my($name,$ttlclass,$type,$rdata) = /$zentry/;
+
+        $rdata =~ s/\s+$//g;
 
 		my($ttl, $class);
 		if(defined $ttlclass) {

--- a/lib/Parse/DNS/Zone.pm
+++ b/lib/Parse/DNS/Zone.pm
@@ -443,7 +443,10 @@ sub _parse_zone {
 			(?: \d+ \s+ ) |
 		)? # <ttl> <class> or <class> <ttl>
 		(\S+)\s+ # type
-		(.*) # rdata
+		(
+			(?: ".*?(?<!\\)" ) |	# quoted rdata
+			(?: .* )			# fall-back rdata
+		)
 	$/ix;
 
 	for (split /\n/, $zonestr) {
@@ -506,7 +509,7 @@ sub _parse_zone {
 
 		my($name,$ttlclass,$type,$rdata) = /$zentry/;
 
-        $rdata =~ s/\s+$//g;
+		$rdata =~ s/\s+$//g;
 
 		my($ttl, $class);
 		if(defined $ttlclass) {

--- a/t/04-domainkey.t
+++ b/t/04-domainkey.t
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 6;
+
+BEGIN { use_ok('Parse::DNS::Zone') }
+
+my %zone_domainkey = (
+	file=>'t/data/db.domainkey',
+	origin=>'example.com.',
+	mname=>'ns1.example.com.',
+	rname=>'hostmaster.example.com.',
+	serial=>1234567890,
+	refresh=>86400,
+	retry=>3600,
+	expire=>3600000,
+	minimum=>14400,
+	names => {
+		'@' => [qw/SOA TXT/],
+		'dkim-multiline' => [qw/TXT/],
+		'dkim-singleline' => [qw/TXT/],
+	},
+);
+
+$zone_domainkey{size} = int(keys %{$zone_domainkey{names}});
+
+if(! -r $zone_domainkey{file}) {
+	BAIL_OUT("$zone_domainkey{file} does not exist");
+}
+
+my $zone = Parse::DNS::Zone->new(
+	zonefile=>$zone_domainkey{file},
+	origin=>$zone_domainkey{origin},
+);
+
+is(
+	int($zone->get_names),
+	$zone_domainkey{size},
+	"expected number of names in zone"
+);
+
+is(
+	$zone->get_rdata(name=>'@', rr=>'TXT'),
+	$zone->get_rdata(name=>$zone_domainkey{origin}, rr=>'TXT'),
+	"@ should translate to origin"
+);
+
+ok(
+	! $zone->get_rdata(name=>'comment.example.com.', rr=>'TXT'),
+	'commented out rr should not exist'
+);
+
+is(
+	$zone->get_rdata(name=>'dk-multiline.example.com.', rr=>'TXT'),
+	'v=DKIM1 descr=multiline foo=bar',
+    "Multiline TXT record is not complete"
+);
+
+is(
+	$zone->get_rdata(name=>'dk-singleline.example.com.', rr=>'TXT'),
+	'"v=DKIM1\; descr=singleline\; fizz=buzz\;"',
+    "Singleline TXT record is not complete"
+);
+

--- a/t/04-domainkey.t
+++ b/t/04-domainkey.t
@@ -53,12 +53,12 @@ ok(
 is(
 	$zone->get_rdata(name=>'dk-multiline.example.com.', rr=>'TXT'),
 	'v=DKIM1 descr=multiline foo=bar',
-    "Multiline TXT record is not complete"
+	"Multiline TXT record is not complete"
 );
 
 is(
 	$zone->get_rdata(name=>'dk-singleline.example.com.', rr=>'TXT'),
 	'"v=DKIM1\; descr=singleline\; fizz=buzz\;"',
-    "Singleline TXT record is not complete"
+	"Singleline TXT record is not complete"
 );
 

--- a/t/data/db.domainkey
+++ b/t/data/db.domainkey
@@ -11,9 +11,9 @@ example.com.	IN		SOA	ns1.example.com. hostmaster.example.com. (
 
 ;comment		TXT	"commented out rr"
 
-dk-multiline	TXT	(           ; Begin multi-line
+dk-multiline	TXT	(	 	 	; Begin multi-line
 					v=DKIM1
-                    descr=multiline
-					foo=bar ) ; End multi-line
+ 					descr=multiline
+					foo=bar )	; End multi-line
 
 dk-singleline	TXT "v=DKIM1\; descr=singleline\; fizz=buzz\;" ; Single line domain key

--- a/t/data/db.domainkey
+++ b/t/data/db.domainkey
@@ -1,0 +1,19 @@
+$TTL	3600
+
+example.com.	IN		SOA	ns1.example.com. hostmaster.example.com. (
+						1234567890	; Serial
+						86400		; Refresh
+						3600		; Retry
+						3600000		; Expire
+						14400  )	; Negative Cache TTL
+
+@				TXT	"A plain text record"
+
+;comment		TXT	"commented out rr"
+
+dk-multiline	TXT	(           ; Begin multi-line
+					v=DKIM1
+                    descr=multiline
+					foo=bar ) ; End multi-line
+
+dk-singleline	TXT "v=DKIM1\; descr=singleline\; fizz=buzz\;" ; Single line domain key


### PR DESCRIPTION
Domain key TXT records sometimes include semi-colons (;) and the previous logic for removing comment text was truncating these during parsing.

This fix gets my use case, but might need further refinements.
