### PR TITLE
Handling of quoted strings, comments and escape characters

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,7 @@ t/01-dist.t
 t/03-filehandling.t
 t/03-fqdnize.t
 t/03-parser.t
+t/03-strip_quotes.t
 t/data/db.include
 t/data/db.nottl
 t/data/db.simple

--- a/lib/Parse/DNS/Zone.pm
+++ b/lib/Parse/DNS/Zone.pm
@@ -448,13 +448,26 @@ sub _parse_zone {
 
 	for (split /\n/, $zonestr) {
 		chomp;
+
+		# Strip away any quoted strings; they should not be parsed in
+		# the same way as the rest of the zonefile. Replace the strings
+		# with placeholders. The real strings are kept in @strs, and
+		# we'll replace them with the real strings again soon.
+		($_, my @strs) = _strip_quotes($_);
+
+		# Strip comments.
 		s/(?<!\\);.*$//;
 		next if /^\s*$/;
+
+		# Normalize in-line whitespace
 		s/\s+/ /g;
 
 		s/^\@ /$origin /g;
 		s/ \@ / $origin /g;
 		s/ \@$/ $origin/g;
+
+		# Re-add the real strings again.
+		$_ = _unstrip_quotes($_, @strs);
 
 		# handles mutlirow entries, with ()
 		if($mrow) {
@@ -553,6 +566,22 @@ sub _parse_zone {
 	}
 
 	return %zone;
+}
+
+sub _strip_quotes {
+	local $_ = shift;
+	my $qstr = qr/(".*?(?<!\\)")/;
+	my @strs = /$qstr/g;
+
+	for my $str (keys @strs) {
+		s/\Q$strs[$str]\E/"\$str[$str]"/;
+	}
+
+	return $_, @strs;
+}
+
+sub _unstrip_quotes {
+	return shift =~ s/"\$str\[([0-9]+)\]"/$_[$1]/gr;
 }
 
 sub _fqdnize {

--- a/lib/Parse/DNS/Zone.pm
+++ b/lib/Parse/DNS/Zone.pm
@@ -448,7 +448,7 @@ sub _parse_zone {
 
 	for (split /\n/, $zonestr) {
 		chomp;
-		s/;.*$//;
+		s/(?<!\\);.*$//;
 		next if /^\s*$/;
 		s/\s+/ /g;
 

--- a/lib/Parse/DNS/Zone.pm
+++ b/lib/Parse/DNS/Zone.pm
@@ -506,6 +506,8 @@ sub _parse_zone {
 
 		my($name,$ttlclass,$type,$rdata) = /$zentry/;
 
+		$rdata =~ s/\s+$//g;
+
 		my($ttl, $class);
 		if(defined $ttlclass) {
 			($ttl) = $ttlclass=~/(\d+)/o;

--- a/t/03-parser.t
+++ b/t/03-parser.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 44;
+use Test::More tests => 47;
 
 BEGIN { use_ok('Parse::DNS::Zone') }
 
@@ -33,6 +33,9 @@ my %zone_simple = (
 		'test-origapp' => [qw/CNAME/],
 		'test-trailing-whitespace' => [qw/TXT/],
 		'test-trailing-whitespace2' => [qw/TXT/],
+		'dk-singleline' => [qw/TXT/],
+		'dk-singleline2' => [qw/TXT/],
+		'dk-multiline' => [qw/TXT/],
 	},
 );
 
@@ -229,6 +232,24 @@ is(
 is(
 	$zone->get_rdata(name=>'test-trailing-whitespace2', rr=>'TXT'),
 	'foo', 'Whitespace between rdata and comment should be ignored'
+);
+
+is(
+	$zone->get_rdata(name=>'dk-multiline.example.com.', rr=>'TXT'),
+	'v=DKIM1 descr=multiline foo=bar',
+	"Multiline TXT record is not complete"
+);
+
+is(
+	$zone->get_rdata(name=>'dk-singleline.example.com.', rr=>'TXT'),
+	'"v=DKIM1\; descr=singleline\; fizz=buzz\;"',
+	"Quoted rdata with escaped ;"
+);
+
+is(
+	$zone->get_rdata(name=>'dk-singleline2.example.com.', rr=>'TXT'),
+	'v=DKIM1\;descr=singleline\;fizz=buzz\;',
+	"Unquoted rdata with escaped ;"
 );
 
 $zone = Parse::DNS::Zone->new(

--- a/t/03-parser.t
+++ b/t/03-parser.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 47;
+use Test::More tests => 50;
 
 BEGIN { use_ok('Parse::DNS::Zone') }
 
@@ -33,8 +33,11 @@ my %zone_simple = (
 		'test-origapp' => [qw/CNAME/],
 		'test-trailing-whitespace' => [qw/TXT/],
 		'test-trailing-whitespace2' => [qw/TXT/],
+		'test-txt-quoted' => [qw/TXT/],
+		'test-txt-quoted-escaped' => [qw/TXT/],
 		'dk-singleline' => [qw/TXT/],
 		'dk-singleline2' => [qw/TXT/],
+		'dk-singleline3' => [qw/TXT/],
 		'dk-multiline' => [qw/TXT/],
 	},
 );
@@ -235,6 +238,18 @@ is(
 );
 
 is(
+	$zone->get_rdata(name=>'test-txt-quoted', rr=>'TXT'),
+	'"foo bar ; baz"',
+	'get TXT quoted rdata'
+);
+
+is(
+	$zone->get_rdata(name=>'test-txt-quoted-escaped', rr=>'TXT'),
+	'"foo b\a\r\ \;\ \b\a\z"',
+	'get TXT quoted (and overly escaped) rdata'
+);
+
+is(
 	$zone->get_rdata(name=>'dk-multiline.example.com.', rr=>'TXT'),
 	'v=DKIM1 descr=multiline foo=bar',
 	"Multiline TXT record is not complete"
@@ -250,6 +265,12 @@ is(
 	$zone->get_rdata(name=>'dk-singleline2.example.com.', rr=>'TXT'),
 	'v=DKIM1\;descr=singleline\;fizz=buzz\;',
 	"Unquoted rdata with escaped ;"
+);
+
+is(
+	$zone->get_rdata(name=>'dk-singleline3.example.com.', rr=>'TXT'),
+	'"v=DKIM1; descr=singleline; fizz=buzz;"',
+	"Quoted rdata with unescaped ;"
 );
 
 $zone = Parse::DNS::Zone->new(

--- a/t/03-parser.t
+++ b/t/03-parser.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 42;
+use Test::More tests => 44;
 
 BEGIN { use_ok('Parse::DNS::Zone') }
 
@@ -31,6 +31,8 @@ my %zone_simple = (
 		'test-ttlclassr' => [qw/A/],
 		'test-include' => [qw/A AAAA/],
 		'test-origapp' => [qw/CNAME/],
+		'test-trailing-whitespace' => [qw/TXT/],
+		'test-trailing-whitespace2' => [qw/TXT/],
 	},
 );
 
@@ -217,6 +219,16 @@ is(
 is(
 	$zone->get_rdata(name=>'test-origapp', rr=>'CNAME', field=>'rdata'),
 	'test', 'Do not append origin to RDATA if not told to do so'
+);
+
+is(
+	$zone->get_rdata(name=>'test-trailing-whitespace', rr=>'TXT'),
+	'foo', 'Trailing whitespace should be ignored'
+);
+
+is(
+	$zone->get_rdata(name=>'test-trailing-whitespace2', rr=>'TXT'),
+	'foo', 'Whitespace between rdata and comment should be ignored'
 );
 
 $zone = Parse::DNS::Zone->new(

--- a/t/03-strip_quotes.t
+++ b/t/03-strip_quotes.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use Parse::DNS::Zone;
+
+sub strip { Parse::DNS::Zone::_strip_quotes(@_) }
+sub unstrip { Parse::DNS::Zone::_unstrip_quotes(@_) }
+
+my %strip = (
+	'no quotes' => ['no quotes'],
+	'with escaped \"' => ['with escaped \"'],
+
+	'with "quotes"' => ['with "$str[0]"', '"quotes"'],
+	'with "two" "quotes"' => [
+		'with "$str[0]" "$str[1]"', '"two"', '"quotes"'
+	],
+	'with "same" "same" quote' => [
+		'with "$str[0]" "$str[1]" quote', '"same"', '"same"'
+	],
+	'with "escaped \" in quote"' => [
+		'with "$str[0]"', '"escaped \" in quote"'
+	],
+);
+
+plan tests => int keys(%strip) * 2;
+
+is_deeply [strip($_)], $strip{$_}, "strip quotes from '$_'"
+	for sort keys %strip;
+is unstrip(@{$strip{$_}}), $_, "unstrip quotes for '$_'"
+	for sort keys %strip;

--- a/t/data/db.simple
+++ b/t/data/db.simple
@@ -39,3 +39,11 @@ test-origapp			CNAME	test
 
 test-trailing-whitespace        TXT     foo 
 test-trailing-whitespace2       TXT     foo ; comment
+
+; DKIM test cases, to verify handling of quoting and escpaing
+dk-singleline	                TXT     "v=DKIM1\; descr=singleline\; fizz=buzz\;" ; Single line domain key
+dk-singleline2	                TXT     v=DKIM1\;descr=singleline\;fizz=buzz\; ; Single line domain key
+dk-multiline	                TXT	(             ; Begin multi-line
+					    v=DKIM1
+                                            descr=multiline
+					    foo=bar ) ; End multi-line

--- a/t/data/db.simple
+++ b/t/data/db.simple
@@ -40,9 +40,13 @@ test-origapp			CNAME	test
 test-trailing-whitespace        TXT     foo 
 test-trailing-whitespace2       TXT     foo ; comment
 
+test-txt-quoted                 TXT     "foo bar ; baz"
+test-txt-quoted-escaped         TXT     "foo b\a\r\ \;\ \b\a\z"
+
 ; DKIM test cases, to verify handling of quoting and escpaing
 dk-singleline	                TXT     "v=DKIM1\; descr=singleline\; fizz=buzz\;" ; Single line domain key
 dk-singleline2	                TXT     v=DKIM1\;descr=singleline\;fizz=buzz\; ; Single line domain key
+dk-singleline3	                TXT     "v=DKIM1; descr=singleline; fizz=buzz;" ; Single line domain key
 dk-multiline	                TXT	(             ; Begin multi-line
 					    v=DKIM1
                                             descr=multiline

--- a/t/data/db.simple
+++ b/t/data/db.simple
@@ -36,3 +36,6 @@ test-ttlclass	400 	IN	A 	127.0.0.1
 test-ttlclassr	IN	400	A 	127.0.0.1
 
 test-origapp			CNAME	test
+
+test-trailing-whitespace        TXT     foo 
+test-trailing-whitespace2       TXT     foo ; comment


### PR DESCRIPTION
As discussed in #3, some cases were not covered. Based on @donckers work, I added additional processing of quoted strings.

@donckers: Since I modified your patches (while retaining your author line), could you take a look and see if it looks ok? And that it still addresses your issues? I've rebased, split it up, and moved it around some. Also moved the new unittests into `db.simple`/`03-parser.t`. I think it's easier to look at them commit by commit.
